### PR TITLE
fix: support dots in shards names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 ### v0.4.0 
 (IN PROGRESS)
 
+### v0.3.1 2025-06-24
+
+Minor change(s):
+- Quote attribute names in shards.nix to allow dots in shard names.
+
 ### v0.3.0 2022-04-09
 
 Major change(s):

--- a/src/worker.cr
+++ b/src/worker.cr
@@ -25,7 +25,7 @@ module Crystal2Nix
             sha256 = PrefetchJSON.from_json(x.output).sha256
           end
 
-          file.puts %(  #{key} = {)
+          file.puts %(  "#{key}" = {)
           file.puts %(    url = "#{repo.url}";)
           file.puts %(    rev = "#{repo.rev}";)
           file.puts %(    sha256 = "#{sha256}";)


### PR DESCRIPTION
Tried using
```yaml
dependencies:
  progress_bar.cr:
    github: tpei/progress_bar.cr
    branch: master
```

It generated shards.nix

```nix
{
  progress_bar.cr = {
    url = "https://github.com/tpei/progress_bar.cr.git";
    rev = "c6be630a1883bb12e61f537b38f30945ae795d5d";
    sha256 = "0hv7agqn4xybph947czn2x7ryvn5y08jqa5ykxx9dyvmzmbdji2n";
  };
}
```

And failed, when calling ```crystal.buildCrystalPackage```.